### PR TITLE
Correct a typo in seg_hrnet_w48_trainval_ohem_512x1024_sgd_lr1e-2_wd5e-4_bs_12_epoch484x2.yaml

### DIFF
--- a/experiments/cityscapes/seg_hrnet_w48_trainval_ohem_512x1024_sgd_lr1e-2_wd5e-4_bs_12_epoch484x2.yaml
+++ b/experiments/cityscapes/seg_hrnet_w48_trainval_ohem_512x1024_sgd_lr1e-2_wd5e-4_bs_12_epoch484x2.yaml
@@ -22,7 +22,7 @@ MODEL:
     FINAL_CONV_KERNEL: 1
     STAGE1:
       NUM_MODULES: 1
-      NUM_RANCHES: 1
+      NUM_BRANCHES: 1
       BLOCK: BOTTLENECK
       NUM_BLOCKS:
       - 4


### PR DESCRIPTION
Correct a typo in `experiments/cityscapes/seg_hrnet_w48_trainval_ohem_512x1024_sgd_lr1e-2_wd5e-4_bs_12_epoch484x2.yaml`