### PR TITLE
Bug fix. Change softmax dim.

### DIFF
--- a/lib/models/seg_hrnet_ocr.py
+++ b/lib/models/seg_hrnet_ocr.py
@@ -61,7 +61,7 @@ class SpatialGather_Module(nn.Module):
         probs = probs.view(batch_size, c, -1)
         feats = feats.view(batch_size, feats.size(1), -1)
         feats = feats.permute(0, 2, 1) # batch x hw x c 
-        probs = F.softmax(self.scale * probs, dim=2)# batch x k x hw
+        probs = F.softmax(self.scale * probs, dim=1)# batch x k x hw
         ocr_context = torch.matmul(probs, feats)\
         .permute(0, 2, 1).unsqueeze(3)# batch x k x c
         return ocr_context


### PR DESCRIPTION
In line 64, Change the softmax dim from 2 to 1.  
According to this line,
`probs = F.softmax(self.scale * probs, dim=2)# batch x k x hw` 

In this code, the input dimension is [batch_size, num_class, fh\*fw]. And the softmax dimension is 2, which means that the summation of the dimensions of the feature map (fh\*fw) is one.

However, in my opinion, I thinke the softmax dimension should be 1 to make the summation of the dimension of the num_class (num_class) is one.

The corrected code is as follows：
`probs = F.softmax(self.scale * probs, dim=1)# batch x num_class x hw`

By the way, I had report this to issue, but without answer.
And I have a simple comparative experimental verification, the results show that dim1 can convergence faster, and get a better mIOU.